### PR TITLE
Remove unicode from titles

### DIFF
--- a/gitchangelog.py
+++ b/gitchangelog.py
@@ -168,7 +168,7 @@ class GithubChangelog(object):
 
             # Add the pull request title to our change log.
             changes.append("* #{} - {} - @{}".format(
-                pull.number, pull.title, pull.user.get("login")
+                pull.number, pull.title.encode('ascii', 'ignore'), pull.user.get("login")
             ))
             self.say("Found closed pull request: {}".format(changes[-1]))
 


### PR DESCRIPTION
Some jerk put unicode in a PR title. When I ran the script I got this error:

```
Traceback (most recent call last):
  File "./gitchangelog.py", line 315, in <module>
    github.main(args)
  File "./gitchangelog.py", line 56, in main
    exclude=args.exclude,
  File "./gitchangelog.py", line 171, in scan_pulls
    pull.number, pull.title, pull.user.get("login")
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 69: ordinal not in range(128)
```

This PR was a quick dirty fix to remove the offensive characters
